### PR TITLE
change options path to baseUrl

### DIFF
--- a/templates/lib/routes/endpoints/dial-time.js
+++ b/templates/lib/routes/endpoints/dial-time.js
@@ -37,7 +37,7 @@ const appJson = require(appJsonPath);
 
 router.options('/', (req, res) => {
   const {logger} = req.app.locals;
-  logger.info(`OPTIONS request received for path: ${req.path}`);
+  logger.info(`OPTIONS request received for path: ${req.baseUrl}`);
 
   // First validate the app.json using SDK's validation
   const validationResult = validateAppConfig(appJson);
@@ -50,7 +50,7 @@ router.options('/', (req, res) => {
   }
 
   // Get the appropriate configuration using SDK's getAppConfig
-  const result = getAppConfig({ urlPath: req.path, appJsonPath });
+  const result = getAppConfig({ urlPath: req.baseUrl, appJsonPath });
   if (!result.success) {
     logger.error(result.error);
     return res.status(500).json({ error: result.error });

--- a/templates/lib/routes/endpoints/record.js
+++ b/templates/lib/routes/endpoints/record.js
@@ -35,7 +35,7 @@ const appJson = require(appJsonPath);
 
 router.options('/', (req, res) => {
   const {logger} = req.app.locals;
-  logger.info(`OPTIONS request received for path: ${req.path}`);
+  logger.info(`OPTIONS request received for path: ${req.baseUrl}`);
 
   // First validate the app.json using SDK's validation
   const validationResult = validateAppConfig(appJson);
@@ -48,7 +48,7 @@ router.options('/', (req, res) => {
   }
 
   // Get the appropriate configuration using SDK's getAppConfig
-  const result = getAppConfig({ urlPath: req.path, appJsonPath });
+  const result = getAppConfig({ urlPath: req.baseUrl, appJsonPath });
   if (!result.success) {
     logger.error(result.error);
     return res.status(500).json({ error: result.error });

--- a/templates/lib/routes/endpoints/tts-hello-world.js
+++ b/templates/lib/routes/endpoints/tts-hello-world.js
@@ -42,7 +42,7 @@ const appJson = require(appJsonPath);
 
 router.options('/', (req, res) => {
   const {logger} = req.app.locals;
-  logger.info(`OPTIONS request received for path: ${req.path}`);
+  logger.info(`OPTIONS request received for path: ${req.baseUrl}`);
 
   // First validate the app.json using SDK's validation
   const validationResult = validateAppConfig(appJson);
@@ -55,7 +55,7 @@ router.options('/', (req, res) => {
   }
 
   // Get the appropriate configuration using SDK's getAppConfig
-  const result = getAppConfig({ urlPath: req.path, appJsonPath });
+  const result = getAppConfig({ urlPath: req.baseUrl, appJsonPath });
   if (!result.success) {
     logger.error(result.error);
     return res.status(500).json({ error: result.error });


### PR DESCRIPTION
using req.path in the application itself was always returning `/` so the lookup in app.json wasn't finding the schema, 
but baseUrl contains the original path